### PR TITLE
Add function arguments to downstream function calls

### DIFF
--- a/balpy/balpy.py
+++ b/balpy/balpy.py
@@ -1350,7 +1350,7 @@ class balpy(object):
 			poolDescription["tokens"][phantomBptAddress] = {"initialBalance":self.MAX_UINT_112}
 
 		poolDescription["joinKind"] = "INIT";
-		return(self.balJoinPool(poolDescription));
+		return(self.balJoinPool(poolDescription, False, gasFactor, gasPriceSpeed, nonceOverride, gasEstimateOverride, gasPriceGweiOverride));
 
 	def balLinearPoolInitJoin(self, poolDescription, poolId, slippageTolerancePercent=1, gasFactor=1.05, gasPriceSpeed="average", nonceOverride=-1, gasEstimateOverride=-1, gasPriceGweiOverride=-1):
 


### PR DESCRIPTION
Fixes an bug when user defines optional arguments in e.g. a pool creation config file. These parameters are passed on to function  `balJoinPoolInit` but not `balJoinPool` which is called within the former function.

Replicate: 
- copy `samples/poolCreation/sampleStablePool.json` to `samples/poolCreation/mySampleStablePool.json`
- set parameter `"gasPriceOverride":"40"' and save file
- execute 'python3 samples/poolCreation/poolCreationSample.py samples/poolCreation/mySampleStablePool.json' 
- you will notice that step 3 (pool creation) applies the gas price but not step 4 (initial join)