### PR TITLE
Optimism API url requires the dash separator

### DIFF
--- a/balpy/balpy.py
+++ b/balpy/balpy.py
@@ -697,7 +697,7 @@ class balpy(object):
 	def generateEtherscanApiUrl(self):
 		etherscanUrl = self.networkParams[self.network]["blockExplorerUrl"]
 		separator = ".";
-		if self.network in ["kovan", "rinkeby","goerli"]:
+		if self.network in ["kovan", "rinkeby","goerli","optimism"]:
 			separator = "-";
 		urlFront = "https://api" + separator + etherscanUrl;
 		return(urlFront);


### PR DESCRIPTION
Small one, but the api url for optimism is https://api-optimistic.etherscan.io/, which is not currently accounted for.